### PR TITLE
[#72] Add style prop to DS components

### DIFF
--- a/ds/docs/stories/2-components/button.stories.tsx
+++ b/ds/docs/stories/2-components/button.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta = {
       linkHref: '',
       linkType: 'internal',
       className: '',
+      style: {},
     },
     events: ['onClick'],
     inlineRadios: ['size', 'variant', 'highlight', 'linkType'],

--- a/ds/docs/stories/2-components/icon-button.stories.tsx
+++ b/ds/docs/stories/2-components/icon-button.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta = {
       linkHref: '',
       linkType: 'internal',
       className: '',
+      style: {},
     },
     events: ['onClick'],
     inlineRadios: ['size', 'variant', 'linkType'],

--- a/ds/docs/stories/2-components/text-field.stories.tsx
+++ b/ds/docs/stories/2-components/text-field.stories.tsx
@@ -32,6 +32,7 @@ const meta: Meta = {
       disabled: false,
       invalid: false,
       className: '',
+      style: {},
     },
     events: ['onChange', 'onSubmit', 'onFocus', 'onBlur'],
     inlineRadios: ['variant', 'size'],

--- a/ds/src/components/_partials/use-base-button.tsx
+++ b/ds/src/components/_partials/use-base-button.tsx
@@ -1,5 +1,5 @@
 import { type CSSObject } from '@emotion/react'
-import { type ReactNode } from 'react'
+import { type CSSProperties, type ReactNode } from 'react'
 import { useThemeService } from '../../services/theme-service'
 import type { LinkType } from './types'
 import { useClickable } from './use-clickable'
@@ -48,6 +48,7 @@ interface BaseButtonProps {
   linkHref?: string
   linkType?: LinkType
   className?: string
+  style?: CSSProperties
 }
 
 export const useBaseButton = (props: BaseButtonProps) => {
@@ -184,6 +185,7 @@ export const useBaseButton = (props: BaseButtonProps) => {
     ...bindings,
     title: props.tooltip,
     className: props.className,
+    style: props.style,
     'aria-description': props.ariaDescription,
     css: cssBaseButton,
   }

--- a/ds/src/components/button/_types.ts
+++ b/ds/src/components/button/_types.ts
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { type CSSProperties, type ReactNode } from 'react'
 import { type LinkType } from '../_partials/types'
 
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'
@@ -55,6 +55,8 @@ export interface ButtonProps {
   linkType?: LinkType
   /** CSS class attribute for the wrapper element */
   className?: string
+  /** CSS style attribute for the wrapper element */
+  style?: CSSProperties
 
   /**
    * Events

--- a/ds/src/components/icon-button/_types.ts
+++ b/ds/src/components/icon-button/_types.ts
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { type CSSProperties, type ReactNode } from 'react'
 import { type LinkType } from '../_partials/types'
 
 export type IconButtonSize = 'xs' | 'sm' | 'md' | 'lg'
@@ -51,6 +51,8 @@ export interface IconButtonProps {
   linkType?: LinkType
   /** CSS class attribute for the wrapper element */
   className?: string
+  /** CSS style attribute for the wrapper element */
+  style?: CSSProperties
 
   /**
    * Events

--- a/ds/src/components/text-field/_types.ts
+++ b/ds/src/components/text-field/_types.ts
@@ -1,4 +1,4 @@
-import { type ReactNode, type Ref } from 'react'
+import { type CSSProperties, type ReactNode, type Ref } from 'react'
 
 export type InputElement = HTMLInputElement & HTMLTextAreaElement
 export type TextFieldVariant = 'default' | 'primary' | 'secondary'
@@ -56,6 +56,8 @@ export interface TextFieldProps {
   invalid?: boolean
   /** CSS class attribute for the wrapper element */
   className?: string
+  /** CSS style attribute for the wrapper element */
+  style?: CSSProperties
 
   /**
    * Events


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Button, Icon Button, and Text Field components now support custom inline styles, providing greater flexibility for styling component instances directly without requiring additional wrapper elements or CSS overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->