### PR TITLE
feat(#86): write and read url params for dataset filters

### DIFF
--- a/app/src/app/datasets/_partials/dataset-table.tsx
+++ b/app/src/app/datasets/_partials/dataset-table.tsx
@@ -1,9 +1,12 @@
+'use client'
+
 import { DataTable, TextHighlight } from '@app-components'
 import { useCountries } from '@app-i18n'
 import { type TableCol } from '@app/shared/types/table'
 import { type JsonStatData, pivotJsonStatTable } from '@app/shared/utils/json-stat'
+import { useSearchParams } from 'next/navigation'
 import { type ReactNode, useCallback, useEffect, useMemo } from 'react'
-import { useTableStore } from '../_table-store'
+import { UrlKey, useTableStore } from '../_table-store'
 import { TableToolbar } from './table-toolbar'
 
 interface Props extends ReactProps {
@@ -12,25 +15,25 @@ interface Props extends ReactProps {
 
 export const DatasetTable = (props: Props) => {
   const { getCountryCode } = useCountries()
-  const indexColKey = useTableStore((s) => s.indexColKey)
-  const pivotColKey = useTableStore((s) => s.pivotColKey)
+  const searchParams = useSearchParams()
+  const indexKey = useTableStore((s) => s.indexKey)
+  const pivotKey = useTableStore((s) => s.pivotKey)
   const filterByCol = useTableStore((s) => s.filterByCol)
   const colQuery = useTableStore((s) => s.colQuery)
   const initTableStore = useTableStore((s) => s.initTableStore)
+  const resetColQuery = useTableStore((s) => s.resetColQuery)
 
   const pivotedData = useMemo(
-    () => pivotJsonStatTable(props.data, { indexColKey, pivotColKey, filterByCol }),
-    [props.data, indexColKey, pivotColKey, filterByCol],
+    () => pivotJsonStatTable(props.data, { indexKey, pivotKey, filterByCol }),
+    [props.data, indexKey, pivotKey, filterByCol],
   )
   const isColVisible = useCallback(
     (col: TableCol) => !col.pivoted || colQuery.some((keyword) => col.label.toLowerCase().includes(keyword)),
     [colQuery],
   )
   const visibleData = useMemo(() => {
-    return pivotColKey && colQuery.length
-      ? { ...pivotedData, cols: pivotedData.cols.filter(isColVisible) }
-      : pivotedData
-  }, [pivotedData, pivotColKey, colQuery, isColVisible])
+    return pivotKey && colQuery.length ? { ...pivotedData, cols: pivotedData.cols.filter(isColVisible) } : pivotedData
+  }, [pivotedData, pivotKey, colQuery, isColVisible])
 
   const cellFn = (value: string, query: string): ReactNode => {
     const flag = getCountryCode(value)
@@ -46,10 +49,18 @@ export const DatasetTable = (props: Props) => {
     initTableStore(props.data)
   }, [props.data])
 
+  useEffect(() => {
+    // Reset all filters when reopening the same dataset
+    if (!searchParams.has(UrlKey.INDEX_KEY)) {
+      initTableStore(props.data)
+      resetColQuery(props.data)
+    }
+  }, [searchParams])
+
   return (
     <DataTable
       data={visibleData}
-      sticky={Boolean(indexColKey && pivotColKey)}
+      sticky={Boolean(indexKey && pivotKey)}
       cellFn={cellFn}
       toolbar={<TableToolbar data={props.data} />}
       className={props.className}

--- a/app/src/app/datasets/_partials/filters-modal.tsx
+++ b/app/src/app/datasets/_partials/filters-modal.tsx
@@ -19,20 +19,20 @@ interface Props {
 export const FiltersModal = (props: Props) => {
   const { t } = useTranslation()
   const { cellsByCol, cols } = props.data
-  const indexColKey = useTableStore((s) => s.indexColKey)
-  const pivotColKey = useTableStore((s) => s.pivotColKey)
+  const indexKey = useTableStore((s) => s.indexKey)
+  const pivotKey = useTableStore((s) => s.pivotKey)
   const filterByCol = useTableStore((s) => s.filterByCol)
-  const setIndexColKey = useTableStore((s) => s.setIndexColKey)
-  const setPivotColKey = useTableStore((s) => s.setPivotColKey)
+  const setIndexKey = useTableStore((s) => s.setIndexKey)
+  const setPivotKey = useTableStore((s) => s.setPivotKey)
   const setFilterByCol = useTableStore((s) => s.setFilterByCol)
   const resetColQuery = useTableStore((s) => s.resetColQuery)
   const colQueryRef = useRef<ColQueryRef>(null)
 
   const colKeys = useMemo(() => {
-    return indexColKey
-      ? Object.keys(cellsByCol).filter((key) => key !== indexColKey && key !== pivotColKey && cellsByCol[key])
+    return indexKey
+      ? Object.keys(cellsByCol).filter((key) => key !== indexKey && key !== pivotKey && cellsByCol[key])
       : []
-  }, [indexColKey, pivotColKey, cellsByCol])
+  }, [indexKey, pivotKey, cellsByCol])
 
   const filterCols = useMemo(
     () => colKeys.map((key) => cols.find((col) => col.key === key)).filter(Boolean) as TableCol[],
@@ -44,7 +44,7 @@ export const FiltersModal = (props: Props) => {
       (acc, key) => ({
         ...acc,
         [key]: cellsByCol[key].map((cell) => ({
-          value: String(cell.value),
+          value: String(cell.code),
           label: String(cell.value),
         })),
       }),
@@ -54,7 +54,7 @@ export const FiltersModal = (props: Props) => {
 
   useEffect(() => {
     resetColQuery(props.data).then(() => colQueryRef.current?.reset())
-  }, [props.data, pivotColKey])
+  }, [props.data, pivotKey])
 
   useEffect(() => {
     colQueryRef.current?.reset()
@@ -74,23 +74,23 @@ export const FiltersModal = (props: Props) => {
           id="filter-index-col"
           colKey=""
           colLabel={t('dataViz.label.fieldLabelForIndex')}
-          value={indexColKey}
+          value={indexKey}
           options={props.indexOptions}
-          onChange={setIndexColKey}
+          onChange={setIndexKey}
         />
         <SettingMemo
           id="filter-pivot-col"
           colKey=""
           colLabel={t('dataViz.label.fieldLabelForPivot')}
-          value={pivotColKey}
+          value={pivotKey}
           options={props.pivotOptions}
-          onChange={setPivotColKey}
+          onChange={setPivotKey}
         />
       </SettingList>
 
       {/* SECTION 2 */}
       <SettingList
-        header={t('dataViz.label.headerFiltersModal2', { count: filterCols.length + (pivotColKey ? 1 : 0) })}
+        header={t('dataViz.label.headerFiltersModal2', { count: filterCols.length + (pivotKey ? 1 : 0) })}
         className="mt-sm-7"
       >
         <ColQueryMemo ref={colQueryRef} />
@@ -147,7 +147,7 @@ interface ColQueryRef {
 const ColQueryMemo = memo(
   forwardRef<ColQueryRef>(function ColQueryMemo(_, ref) {
     const { t } = useTranslation()
-    const pivotColKey = useTableStore((s) => s.pivotColKey)
+    const pivotKey = useTableStore((s) => s.pivotKey)
     const colQuery = useTableStore((s) => s.colQuery)
     const setColQuery = useTableStore((s) => s.setColQuery)
     const [colQueryText, setColQueryText] = useState('')
@@ -173,7 +173,7 @@ const ColQueryMemo = memo(
       reset: resetColQueryText,
     }))
 
-    if (!pivotColKey) return null
+    if (!pivotKey) return null
     return (
       <div>
         <dt>

--- a/app/src/app/datasets/_partials/table-toolbar.tsx
+++ b/app/src/app/datasets/_partials/table-toolbar.tsx
@@ -14,30 +14,30 @@ interface Props {
 export const TableToolbar = (props: Props) => {
   const { t } = useTranslation()
   const { isViewportMinXL, isViewportMD } = useViewportService()
-  const indexColKey = useTableStore((s) => s.indexColKey)
-  const pivotColKey = useTableStore((s) => s.pivotColKey)
+  const indexKey = useTableStore((s) => s.indexKey)
+  const pivotKey = useTableStore((s) => s.pivotKey)
   const { cellsByCol, cols } = props.data
   const isMdOrLarger = isViewportMinXL || isViewportMD
   const [openedModal, setOpenedModal] = useState(false)
   const colKeys = useMemo(() => [...Object.keys(cellsByCol), ''], [cellsByCol])
-  const filterCount = (indexColKey ? colKeys.length - (pivotColKey ? 3 : 2) : 0) + (pivotColKey ? 1 : 0)
+  const filterCount = (indexKey ? colKeys.length - (pivotKey ? 3 : 2) : 0) + (pivotKey ? 1 : 0)
   const getColLabel = useCallback((key: string) => cols.find((col) => col.key === key)?.label || key, [cols])
 
   const indexOptions = useMemo((): SelectOption[] => {
     return colKeys.map((key) => ({
       value: key,
       label: key ? getColLabel(key) : t('dataViz.label.emptyOptionForIndex'),
-      disabled: Boolean(key && key === pivotColKey),
+      disabled: Boolean(key && key === pivotKey),
     }))
-  }, [colKeys, pivotColKey, t, getColLabel])
+  }, [colKeys, pivotKey, t, getColLabel])
 
   const pivotOptions = useMemo((): SelectOption[] => {
     return colKeys.map((key) => ({
       value: key,
       label: key ? getColLabel(key) : t('dataViz.label.emptyOptionForPivot'),
-      disabled: Boolean(key && key === indexColKey),
+      disabled: Boolean(key && key === indexKey),
     }))
-  }, [colKeys, indexColKey, t, getColLabel])
+  }, [colKeys, indexKey, t, getColLabel])
 
   return (
     <div className="gap-xs-2 flex w-full items-center justify-between lg:w-fit">
@@ -83,22 +83,22 @@ interface RowColProps {
 
 const IndexPivotMemo = memo(function IndexPivotMemo(props: RowColProps) {
   const { t } = useTranslation()
-  const indexColKey = useTableStore((s) => s.indexColKey)
-  const pivotColKey = useTableStore((s) => s.pivotColKey)
-  const setIndexColKey = useTableStore((s) => s.setIndexColKey)
-  const setPivotColKey = useTableStore((s) => s.setPivotColKey)
+  const indexKey = useTableStore((s) => s.indexKey)
+  const pivotKey = useTableStore((s) => s.pivotKey)
+  const setIndexKey = useTableStore((s) => s.setIndexKey)
+  const setPivotKey = useTableStore((s) => s.setPivotKey)
   const wrapperClass = cx('xl:min-w-lg-0 max-w-lg-7 flex-1')
 
   return (
     <div className="flex flex-1 items-center">
       <Tooltip label={t('dataViz.label.fieldLabelForIndex')} className={wrapperClass}>
-        <SelectField id="index-col" options={props.indexOptions} value={indexColKey} onChange={setIndexColKey} />
+        <SelectField id="index-col" options={props.indexOptions} value={indexKey} onChange={setIndexKey} />
       </Tooltip>
 
       <CloseSvg className="h-xs-4 mx-xs-2 text-color-text-placeholder" />
 
       <Tooltip label={t('dataViz.label.fieldLabelForPivot')} className={wrapperClass}>
-        <SelectField id="pivot-col" options={props.pivotOptions} value={pivotColKey} onChange={setPivotColKey} />
+        <SelectField id="pivot-col" options={props.pivotOptions} value={pivotKey} onChange={setPivotKey} />
       </Tooltip>
     </div>
   )

--- a/app/src/app/datasets/_table-store.ts
+++ b/app/src/app/datasets/_table-store.ts
@@ -1,45 +1,60 @@
 import { EurostatConfig, type JsonStatData } from '@app/shared/utils/json-stat'
+import { getUrlParam, setUrlParam } from '@app/shared/utils/url-query'
 import { create } from 'zustand'
 
 interface TableStore {
-  indexColKey: string
-  pivotColKey: string
+  indexKey: string
+  pivotKey: string
   filterByCol: Record<string, string>
   colQuery: string[]
   initTableStore: (data: JsonStatData) => Promise<void>
   resetColQuery: (data: JsonStatData) => Promise<void>
-  setIndexColKey: (value: string | null) => void
-  setPivotColKey: (value: string | null) => void
-  setFilterByCol: (value: string | null, key: string) => void
+  setIndexKey: (value: string | null) => void
+  setPivotKey: (value: string | null) => void
   setColQuery: (value: string[]) => void
+  setFilterByCol: (value: string | null, key: string) => void
 }
 
-export const useTableStore = create<TableStore>((set) => ({
-  indexColKey: '',
-  pivotColKey: '',
+const useTableStore = create<TableStore>((set) => ({
+  indexKey: '',
+  pivotKey: '',
   filterByCol: {},
   colQuery: [],
 
   initTableStore: async (data: JsonStatData) => {
     if (data.source !== 'eurostat') return
 
-    const { DEFAULT_ROW_KEY, DEFAULT_COL_KEY, DEFAULT_FILTERS } = EurostatConfig
-    const colKeys = Object.keys(data.cellsByCol)
+    const { DEFAULT_INDEX_KEY, DEFAULT_PIVOT_KEY, DEFAULT_FILTERS } = EurostatConfig
+    const colQuery = getUrlParam<string[]>(UrlKey.COL_QUERY) || []
 
-    set({
-      indexColKey: data.cellsByCol[DEFAULT_ROW_KEY] ? DEFAULT_ROW_KEY : '',
-      pivotColKey: data.cellsByCol[DEFAULT_COL_KEY] ? DEFAULT_COL_KEY : '',
-      filterByCol: colKeys.reduce(
-        (acc, key) => {
-          const defaultCode = DEFAULT_FILTERS[key as keyof typeof DEFAULT_FILTERS]
-          const cell = defaultCode
-            ? data.cellsByCol[key]?.find((cell) => cell.code === defaultCode)
-            : data.cellsByCol[key]?.[0]
-          return { ...acc, [key]: String(cell?.value ?? '') }
-        },
-        {} as Record<string, string>,
-      ),
-    })
+    const defaultIndexKey = data.cellsByCol[DEFAULT_INDEX_KEY] ? DEFAULT_INDEX_KEY : ''
+    const defaultPivotKey = data.cellsByCol[DEFAULT_PIVOT_KEY] ? DEFAULT_PIVOT_KEY : ''
+    let indexKey = getUrlParam<string>(UrlKey.INDEX_KEY)
+    let pivotKey = getUrlParam<string>(UrlKey.PIVOT_KEY)
+    indexKey = indexKey !== null && (indexKey === '' || data.cellsByCol[indexKey]) ? indexKey : defaultIndexKey
+    pivotKey = pivotKey !== null && (pivotKey === '' || data.cellsByCol[pivotKey]) ? pivotKey : defaultPivotKey
+
+    const getDefaultFilter = (key: string) => {
+      const defaultCode = DEFAULT_FILTERS[key as keyof typeof DEFAULT_FILTERS]
+      const cell = defaultCode
+        ? data.cellsByCol[key]?.find((cell) => cell.code === defaultCode)
+        : data.cellsByCol[key]?.[0]
+      return String(cell?.code ?? '')
+    }
+    const filterByCol = Object.keys(data.cellsByCol).reduce(
+      (acc, key) => {
+        const code = getUrlParam<string>(UrlKey.PREFIX + key)
+        const isValid = code !== null && data.cellsByCol[key]?.some((cell) => String(cell.code) === code)
+        return { ...acc, [key]: isValid ? code : getDefaultFilter(key) }
+      },
+      {} as Record<string, string>,
+    )
+
+    setUrlParam(UrlKey.INDEX_KEY, indexKey)
+    setUrlParam(UrlKey.PIVOT_KEY, pivotKey)
+    setUrlParam(UrlKey.COL_QUERY, colQuery)
+    Object.entries(filterByCol).forEach(([key, value]) => setUrlParam(UrlKey.PREFIX + key, value))
+    set({ indexKey, pivotKey, colQuery, filterByCol })
   },
 
   resetColQuery: async (data: JsonStatData) => {
@@ -48,13 +63,36 @@ export const useTableStore = create<TableStore>((set) => ({
     const currentYear = new Date().getFullYear()
     const timeQuery = [String(currentYear - 1), String(currentYear)]
 
-    set((state) => ({ colQuery: state.pivotColKey === EurostatConfig.TIME_KEY ? timeQuery : [] }))
+    set((state) => {
+      const colQuery = state.pivotKey === EurostatConfig.TIME_KEY ? timeQuery : []
+      setUrlParam(UrlKey.COL_QUERY, colQuery)
+      return { colQuery }
+    })
   },
 
-  setIndexColKey: (value: string | null) => set({ indexColKey: value || '' }),
-  setPivotColKey: (value: string | null) => set({ pivotColKey: value || '' }),
+  setIndexKey: (value: string | null) => {
+    setUrlParam(UrlKey.INDEX_KEY, value || '')
+    set({ indexKey: value || '' })
+  },
+  setPivotKey: (value: string | null) => {
+    setUrlParam(UrlKey.PIVOT_KEY, value || '')
+    set({ pivotKey: value || '' })
+  },
+  setColQuery: (value: string[]) => {
+    setUrlParam(UrlKey.COL_QUERY, value)
+    set({ colQuery: value })
+  },
   setFilterByCol: (value: string | null, key: string) => {
+    setUrlParam(UrlKey.PREFIX + key, value || '')
     set((state) => ({ filterByCol: { ...state.filterByCol, [key]: value || '' } }))
   },
-  setColQuery: (value: string[]) => set({ colQuery: value }),
 }))
+
+const UrlKey = {
+  INDEX_KEY: 'indexKey',
+  PIVOT_KEY: 'pivotKey',
+  COL_QUERY: 'colQuery',
+  PREFIX: '_',
+} as const
+
+export { UrlKey, useTableStore }

--- a/app/src/shared/utils/json-stat/_pivot-table.ts
+++ b/app/src/shared/utils/json-stat/_pivot-table.ts
@@ -1,55 +1,60 @@
 import type { TableCol, TableData, TableRow } from '../../types/table'
-import { JSON_STAT_VALUE_KEY } from './_types'
+import { JSON_STAT_VALUE_KEY, type JsonStatData } from './_types'
 
 type PivotConfig = {
-  indexColKey: string
-  pivotColKey: string
+  indexKey: string
+  pivotKey: string
   filterByCol: Record<string, string>
 }
 
-const pivotJsonStatTable = (data: TableData, { indexColKey, pivotColKey, filterByCol }: PivotConfig): TableData => {
-  const filterEntries = indexColKey
-    ? Object.entries(filterByCol).filter(([key, value]) => value !== '' && key !== indexColKey && key !== pivotColKey)
+const pivotJsonStatTable = (data: JsonStatData, { indexKey, pivotKey, filterByCol }: PivotConfig): TableData => {
+  const filterEntries = indexKey
+    ? Object.entries(filterByCol)
+        .filter(([key, value]) => value !== '' && key !== indexKey && key !== pivotKey)
+        .map(([key, code]) => {
+          const value = data.cellsByCol[key]?.find((cell) => cell.code === code)?.value || ''
+          return [key, value]
+        })
     : []
-  const filteredRows = indexColKey
+  const filteredRows = indexKey
     ? data.rows.filter((row) => filterEntries.every(([key, value]) => String(row[key]) === value))
     : data.rows
   let finalCols: TableCol[]
   let finalRows: TableRow[]
 
-  if (pivotColKey) {
+  if (pivotKey) {
     const rowMap = new Map<string, TableRow>()
     for (const row of filteredRows) {
       const indexColValue = Object.entries(row)
-        .filter(([key]) => key !== pivotColKey && key !== JSON_STAT_VALUE_KEY)
+        .filter(([key]) => key !== pivotKey && key !== JSON_STAT_VALUE_KEY)
         .map(([, val]) => String(val))
         .join('||') // Add separator to avoid conflicts
       if (!rowMap.has(indexColValue)) {
         rowMap.set(
           indexColValue,
-          Object.fromEntries(Object.entries(row).filter(([key]) => key !== pivotColKey && key !== JSON_STAT_VALUE_KEY)),
+          Object.fromEntries(Object.entries(row).filter(([key]) => key !== pivotKey && key !== JSON_STAT_VALUE_KEY)),
         )
       }
-      rowMap.get(indexColValue)![String(row[pivotColKey])] = row[JSON_STAT_VALUE_KEY]
+      rowMap.get(indexColValue)![String(row[pivotKey])] = row[JSON_STAT_VALUE_KEY]
     }
 
-    const isIndexCol = (col: TableCol) => !indexColKey || col.key === indexColKey
-    const isNoPivotCol = (col: TableCol) => col.key !== JSON_STAT_VALUE_KEY && col.key !== pivotColKey
+    const isIndexCol = (col: TableCol) => !indexKey || col.key === indexKey
+    const isNoPivotCol = (col: TableCol) => col.key !== JSON_STAT_VALUE_KEY && col.key !== pivotKey
     const indexCols = data.cols.filter((col) => isIndexCol(col) && isNoPivotCol(col))
-    const pivotValues = [...new Set(data.rows.map((row) => String(row[pivotColKey])))]
+    const pivotValues = [...new Set(data.rows.map((row) => String(row[pivotKey])))]
     const pivotCols = pivotValues.map((value): TableCol => ({ key: value, label: value, type: 'float', pivoted: true }))
     finalCols = [...indexCols, ...pivotCols]
     finalRows = [...rowMap.values()]
   } else {
-    finalCols = data.cols.filter((col) => !indexColKey || col.key === indexColKey || col.key === JSON_STAT_VALUE_KEY)
+    finalCols = data.cols.filter((col) => !indexKey || col.key === indexKey || col.key === JSON_STAT_VALUE_KEY)
     finalRows = filteredRows
   }
 
   // Backfill missing index rows
-  if (indexColKey) {
-    const allIndexValues = new Set(data.rows.map((row) => row[indexColKey]))
+  if (indexKey) {
+    const allIndexValues = new Set(data.rows.map((row) => row[indexKey]))
     finalRows = [...allIndexValues].map<TableRow>(
-      (indexValue) => finalRows.find((row) => row[indexColKey] === indexValue) || { [indexColKey]: indexValue },
+      (indexValue) => finalRows.find((row) => row[indexKey] === indexValue) || { [indexKey]: indexValue },
     )
   }
 

--- a/app/src/shared/utils/json-stat/_types.ts
+++ b/app/src/shared/utils/json-stat/_types.ts
@@ -54,8 +54,8 @@ const JsonStatSchema = z.object({
 }) satisfies z.ZodType<JsonStat>
 
 const EurostatConfig = {
-  DEFAULT_COL_KEY: 'time',
-  DEFAULT_ROW_KEY: 'geo',
+  DEFAULT_INDEX_KEY: 'geo',
+  DEFAULT_PIVOT_KEY: 'time',
   DEFAULT_FILTERS: {
     partner: 'WRL_REST',
   },

--- a/app/src/shared/utils/url-query.ts
+++ b/app/src/shared/utils/url-query.ts
@@ -1,0 +1,21 @@
+const getUrlParams = (): URLSearchParams => new URLSearchParams(window.location.search)
+
+const getUrlParam = <T extends string | string[]>(key: string): T | null => {
+  const value = getUrlParams().get(key)
+  if (value === null) return null
+  if (value.includes(',')) return value.split(',') as T
+  return value as T
+}
+
+const setUrlParam = (key: string, value: string | string[]) => {
+  const params = getUrlParams()
+  const isEmpty = Array.isArray(value) ? !value.length : value === null
+  if (isEmpty) {
+    params.delete(key)
+  } else {
+    params.set(key, Array.isArray(value) ? value.join(',') : value)
+  }
+  window.history.replaceState(null, '', `${window.location.pathname}?${params}`)
+}
+
+export { getUrlParam, getUrlParams, setUrlParam }


### PR DESCRIPTION
feat(#86): add url-query utilities
refactor(#86): use column codes instead of values for `filterByCol`
refactor(#86): rename `indexColKey` and `pivotColKey` to `indexKey` and `pivotKey`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added URL state persistence for table configurations, allowing users to bookmark and share filtered dataset views with index, pivot, and column query settings preserved.

* **Refactor**
  * Reorganized internal table configuration logic to improve state management consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->