### PR TITLE
fix(#86): fix colQuery url param when pivot key changes

### DIFF
--- a/app/src/app/datasets/_partials/dataset-table.tsx
+++ b/app/src/app/datasets/_partials/dataset-table.tsx
@@ -19,21 +19,20 @@ export const DatasetTable = (props: Props) => {
   const indexKey = useTableStore((s) => s.indexKey)
   const pivotKey = useTableStore((s) => s.pivotKey)
   const filterByCol = useTableStore((s) => s.filterByCol)
-  const colQuery = useTableStore((s) => s.colQuery)
+  const pivotQuery = useTableStore((s) => s.pivotQuery)
   const initTableStore = useTableStore((s) => s.initTableStore)
-  const resetColQuery = useTableStore((s) => s.resetColQuery)
 
   const pivotedData = useMemo(
     () => pivotJsonStatTable(props.data, { indexKey, pivotKey, filterByCol }),
     [props.data, indexKey, pivotKey, filterByCol],
   )
   const isColVisible = useCallback(
-    (col: TableCol) => !col.pivoted || colQuery.some((keyword) => col.label.toLowerCase().includes(keyword)),
-    [colQuery],
+    (col: TableCol) => !col.pivoted || pivotQuery.some((keyword) => col.label.toLowerCase().includes(keyword)),
+    [pivotQuery],
   )
   const visibleData = useMemo(() => {
-    return pivotKey && colQuery.length ? { ...pivotedData, cols: pivotedData.cols.filter(isColVisible) } : pivotedData
-  }, [pivotedData, pivotKey, colQuery, isColVisible])
+    return pivotKey && pivotQuery.length ? { ...pivotedData, cols: pivotedData.cols.filter(isColVisible) } : pivotedData
+  }, [pivotedData, pivotKey, pivotQuery, isColVisible])
 
   const cellFn = (value: string, query: string): ReactNode => {
     const flag = getCountryCode(value)
@@ -53,7 +52,6 @@ export const DatasetTable = (props: Props) => {
     // Reset all filters when reopening the same dataset
     if (!searchParams.has(UrlKey.INDEX_KEY)) {
       initTableStore(props.data)
-      resetColQuery(props.data)
     }
   }, [searchParams])
 

--- a/app/src/app/datasets/_partials/filters-modal.tsx
+++ b/app/src/app/datasets/_partials/filters-modal.tsx
@@ -148,16 +148,16 @@ const ColQueryMemo = memo(
   forwardRef<ColQueryRef>(function ColQueryMemo(_, ref) {
     const { t } = useTranslation()
     const pivotKey = useTableStore((s) => s.pivotKey)
-    const colQuery = useTableStore((s) => s.colQuery)
-    const setColQuery = useTableStore((s) => s.setColQuery)
+    const pivotQuery = useTableStore((s) => s.pivotQuery)
+    const setPivotQuery = useTableStore((s) => s.setPivotQuery)
     const [colQueryText, setColQueryText] = useState('')
 
     const resetColQueryText = () => {
-      setColQueryText(colQuery.join(' OR '))
+      setColQueryText(pivotQuery.join(' OR '))
     }
     const handleColQueryChange = debounce((value: string) => {
       setColQueryText(value)
-      setColQuery(
+      setPivotQuery(
         value
           .split(' OR ')
           .map((v) => v.trim().toLowerCase())
@@ -166,7 +166,7 @@ const ColQueryMemo = memo(
     }, 300)
     const handleColQueryClear = () => {
       setColQueryText('')
-      setColQuery([])
+      setPivotQuery([])
     }
 
     useImperativeHandle(ref, () => ({

--- a/app/src/app/datasets/_table-store.ts
+++ b/app/src/app/datasets/_table-store.ts
@@ -1,38 +1,39 @@
 import { EurostatConfig, type JsonStatData } from '@app/shared/utils/json-stat'
-import { getUrlParam, setUrlParam } from '@app/shared/utils/url-query'
+import { deleteUrlParam, getUrlParam, getUrlParamArray, setUrlParam } from '@app/shared/utils/url-query'
 import { create } from 'zustand'
 
 interface TableStore {
   indexKey: string
   pivotKey: string
+  pivotQuery: string[]
   filterByCol: Record<string, string>
-  colQuery: string[]
   initTableStore: (data: JsonStatData) => Promise<void>
   resetColQuery: (data: JsonStatData) => Promise<void>
   setIndexKey: (value: string | null) => void
   setPivotKey: (value: string | null) => void
-  setColQuery: (value: string[]) => void
+  setPivotQuery: (value: string[]) => void
   setFilterByCol: (value: string | null, key: string) => void
 }
 
 const useTableStore = create<TableStore>((set) => ({
   indexKey: '',
   pivotKey: '',
+  pivotQuery: [],
   filterByCol: {},
-  colQuery: [],
 
   initTableStore: async (data: JsonStatData) => {
     if (data.source !== 'eurostat') return
 
     const { DEFAULT_INDEX_KEY, DEFAULT_PIVOT_KEY, DEFAULT_FILTERS } = EurostatConfig
-    const colQuery = getUrlParam<string[]>(UrlKey.COL_QUERY) || []
 
     const defaultIndexKey = data.cellsByCol[DEFAULT_INDEX_KEY] ? DEFAULT_INDEX_KEY : ''
     const defaultPivotKey = data.cellsByCol[DEFAULT_PIVOT_KEY] ? DEFAULT_PIVOT_KEY : ''
-    let indexKey = getUrlParam<string>(UrlKey.INDEX_KEY)
-    let pivotKey = getUrlParam<string>(UrlKey.PIVOT_KEY)
+    let indexKey = getUrlParam(UrlKey.INDEX_KEY)
+    let pivotKey = getUrlParam(UrlKey.PIVOT_KEY)
     indexKey = indexKey !== null && (indexKey === '' || data.cellsByCol[indexKey]) ? indexKey : defaultIndexKey
     pivotKey = pivotKey !== null && (pivotKey === '' || data.cellsByCol[pivotKey]) ? pivotKey : defaultPivotKey
+
+    const pivotQuery = getUrlParamArray(UrlKey.PIVOT_QUERY) || computePivotQuery(pivotKey)
 
     const getDefaultFilter = (key: string) => {
       const defaultCode = DEFAULT_FILTERS[key as keyof typeof DEFAULT_FILTERS]
@@ -43,7 +44,7 @@ const useTableStore = create<TableStore>((set) => ({
     }
     const filterByCol = Object.keys(data.cellsByCol).reduce(
       (acc, key) => {
-        const code = getUrlParam<string>(UrlKey.PREFIX + key)
+        const code = getUrlParam(UrlKey.PREFIX + key)
         const isValid = code !== null && data.cellsByCol[key]?.some((cell) => String(cell.code) === code)
         return { ...acc, [key]: isValid ? code : getDefaultFilter(key) }
       },
@@ -52,21 +53,18 @@ const useTableStore = create<TableStore>((set) => ({
 
     setUrlParam(UrlKey.INDEX_KEY, indexKey)
     setUrlParam(UrlKey.PIVOT_KEY, pivotKey)
-    setUrlParam(UrlKey.COL_QUERY, colQuery)
+    setUrlParam(UrlKey.PIVOT_QUERY, pivotQuery)
     Object.entries(filterByCol).forEach(([key, value]) => setUrlParam(UrlKey.PREFIX + key, value))
-    set({ indexKey, pivotKey, colQuery, filterByCol })
+    set({ indexKey, pivotKey, pivotQuery, filterByCol })
   },
 
   resetColQuery: async (data: JsonStatData) => {
     if (data.source !== 'eurostat') return
 
-    const currentYear = new Date().getFullYear()
-    const timeQuery = [String(currentYear - 1), String(currentYear)]
-
     set((state) => {
-      const colQuery = state.pivotKey === EurostatConfig.TIME_KEY ? timeQuery : []
-      setUrlParam(UrlKey.COL_QUERY, colQuery)
-      return { colQuery }
+      const pivotQuery = getUrlParamArray(UrlKey.PIVOT_QUERY) || computePivotQuery(state.pivotKey)
+      setUrlParam(UrlKey.PIVOT_QUERY, pivotQuery)
+      return { pivotQuery }
     })
   },
 
@@ -76,11 +74,12 @@ const useTableStore = create<TableStore>((set) => ({
   },
   setPivotKey: (value: string | null) => {
     setUrlParam(UrlKey.PIVOT_KEY, value || '')
+    deleteUrlParam(UrlKey.PIVOT_QUERY) // Recompute query when changing pivot key
     set({ pivotKey: value || '' })
   },
-  setColQuery: (value: string[]) => {
-    setUrlParam(UrlKey.COL_QUERY, value)
-    set({ colQuery: value })
+  setPivotQuery: (value: string[]) => {
+    setUrlParam(UrlKey.PIVOT_QUERY, value)
+    set({ pivotQuery: value })
   },
   setFilterByCol: (value: string | null, key: string) => {
     setUrlParam(UrlKey.PREFIX + key, value || '')
@@ -88,10 +87,16 @@ const useTableStore = create<TableStore>((set) => ({
   },
 }))
 
+const computePivotQuery = (pivotKey: string) => {
+  const currentYear = new Date().getFullYear()
+  const timeQuery = [String(currentYear - 1), String(currentYear)]
+  return pivotKey === EurostatConfig.TIME_KEY ? timeQuery : []
+}
+
 const UrlKey = {
   INDEX_KEY: 'indexKey',
   PIVOT_KEY: 'pivotKey',
-  COL_QUERY: 'colQuery',
+  PIVOT_QUERY: 'pivotQuery',
   PREFIX: '_',
 } as const
 

--- a/app/src/shared/utils/url-query.ts
+++ b/app/src/shared/utils/url-query.ts
@@ -1,21 +1,27 @@
 const getUrlParams = (): URLSearchParams => new URLSearchParams(window.location.search)
 
-const getUrlParam = <T extends string | string[]>(key: string): T | null => {
+const getUrlParam = (key: string): string | null => getUrlParams().get(key)
+const getUrlParamArray = (key: string): string[] | null => {
   const value = getUrlParams().get(key)
   if (value === null) return null
-  if (value.includes(',')) return value.split(',') as T
-  return value as T
+  if (value === '') return []
+  return value.split(',')
 }
 
 const setUrlParam = (key: string, value: string | string[]) => {
   const params = getUrlParams()
-  const isEmpty = Array.isArray(value) ? !value.length : value === null
-  if (isEmpty) {
-    params.delete(key)
+  if (Array.isArray(value) && !value.length) {
+    params.set(key, '')
   } else {
     params.set(key, Array.isArray(value) ? value.join(',') : value)
   }
   window.history.replaceState(null, '', `${window.location.pathname}?${params}`)
 }
 
-export { getUrlParam, getUrlParams, setUrlParam }
+const deleteUrlParam = (key: string) => {
+  const params = getUrlParams()
+  params.delete(key)
+  window.history.replaceState(null, '', `${window.location.pathname}?${params}`)
+}
+
+export { deleteUrlParam, getUrlParam, getUrlParamArray, getUrlParams, setUrlParam }


### PR DESCRIPTION
refactor(#86): improve url query utilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Column filter state is now tied to the active pivot and persists when reopening datasets, preserving your visible columns and filters.
  * Filter input and modal behavior unchanged but now persist and reflect pivot-specific context (including automatic time-range defaults when pivoting by time).
  * Filter state is encoded in the URL so links preserve pivot-aware filters and column visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->